### PR TITLE
markdown updates

### DIFF
--- a/ORM Cookbook/DocumentationDocNet/Immutable.md
+++ b/ORM Cookbook/DocumentationDocNet/Immutable.md
@@ -33,7 +33,7 @@ No special handling is needed to call a non-default constructor.
 
 ## Entity Framework Core
 
-NHibernate does not directly support immutable objects. You can overcome this by using a pair of conversions between the immutable object and the mutable entity.
+Entity Framework Core does not directly support immutable objects. You can overcome this by using a pair of conversions between the immutable object and the mutable entity.
 
 @snippet cs [..\Recipes.EntityFrameworkCore\Immutable\ReadOnlyEmployeeClassification.cs] <Constructor>(EmployeeClassification)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The .NET Core ORM Cookbook
 
-In October of 2016, InfoQ published a series of articles on the repository pattern in .NET. To illustrate the concepts three ORMs were demonstrated:  Entity Framework, Dapper, and Chain. 
+In October of 2016, InfoQ published a series of articles on the repository pattern in .NET. To illustrate the concepts, three ORMs were demonstrated:  Entity Framework, Dapper, and Chain. 
 
-A criticism of the articles was that it didn’t include many people’s favorite ORM. So as a follow up, this GitHub repository was created to expand on that idea and create a shared “cookbook” of design patterns for any or all of the .NET ORMs. Contributions are welcome.
+A criticism of the articles was that it didn't include many people's favorite ORM. So as a follow up, this GitHub repository was created to expand on that idea and create a shared "cookbook" of design patterns for any or all of the .NET ORMs. Contributions are welcome.
 
 With this in mind, we'd like to present [The ORM Cookbook](https://grauenwolf.github.io/DotNet-ORM-Cookbook/)
 
@@ -26,4 +26,4 @@ To ensure each ORM is "playing by the rules", a shared set of tests will be used
 
 Each use case has a matching markdown file in which the code samples can be added along with any relevant explanations. When possible, use [Projbook]( http://defrancea.github.io/Projbook/) notation to inline code samples. This will prevent the code samples from getting out of sync with the documentation.
 
-If you build the “Documentation” project, the cookbook will be compiled as a website file. 
+If you build the "Documentation" project, the cookbook will be compiled as a website file. 


### PR DESCRIPTION
Fix EF Core label reference error in docs
Minor corrections (unicode "smart Quotes" to normal quotes, add comma)