### PR TITLE
Used the Microsoft.Data.SqlClient namespace and the latest package ve…

### DIFF
--- a/ORM Cookbook/Recipes.RepoDb/BasicStoredProc/BasicStoredProcScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/BasicStoredProc/BasicStoredProcScenario.cs
@@ -1,11 +1,11 @@
-﻿using Recipes.BasicStoredProc;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.BasicStoredProc;
 using Recipes.RepoDb.Models;
 using RepoDb;
 using RepoDb.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using System.Linq;
 
 using RDB = RepoDb;

--- a/ORM Cookbook/Recipes.RepoDb/BulkInsert/BulkInsertScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/BulkInsert/BulkInsertScenario.cs
@@ -1,10 +1,10 @@
-﻿using Recipes.BulkInsert;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.BulkInsert;
 using Recipes.RepoDb.Models;
 using RepoDb;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 
 namespace Recipes.RepoDb.BulkInsert
 {

--- a/ORM Cookbook/Recipes.RepoDb/DynamicSorting/DynamicSortingScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/DynamicSorting/DynamicSortingScenario.cs
@@ -1,11 +1,11 @@
-﻿using Recipes.DynamicSorting;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.DynamicSorting;
 using Recipes.RepoDb.Models;
 using RepoDb;
 using RepoDb.Enumerations;
 using RepoDb.Extensions;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 
 namespace Recipes.RepoDb.DynamicSorting
 {

--- a/ORM Cookbook/Recipes.RepoDb/Immutable/ImmutableScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/Immutable/ImmutableScenario.cs
@@ -5,8 +5,8 @@ using RDB = RepoDb;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Data.SqlClient;
 using System.Linq;
+using Microsoft.Data.SqlClient;
 
 namespace Recipes.RepoDb.Immutable
 {

--- a/ORM Cookbook/Recipes.RepoDb/Joins/JoinsScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/Joins/JoinsScenario.cs
@@ -1,14 +1,12 @@
-﻿using Recipes.RepoDb.Models;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.RepoDb.Models;
 using Recipes.Joins;
-using System;
-using System.Collections.Generic;
-using System.Data.SqlClient;
-using RepoDb;
-
 using RDB = RepoDb;
-
+using RepoDb;
 using RepoDb.Extensions;
+using System;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace Recipes.RepoDb.Joins
 {

--- a/ORM Cookbook/Recipes.RepoDb/LargeBatch/LargeBatchScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/LargeBatch/LargeBatchScenario.cs
@@ -1,9 +1,9 @@
-﻿using Recipes.LargeBatch;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.LargeBatch;
 using Recipes.RepoDb.Models;
 using RepoDb;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
 
 using RDB = RepoDb;

--- a/ORM Cookbook/Recipes.RepoDb/ModelWithChildren/ModelWithChildrenScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/ModelWithChildren/ModelWithChildrenScenario.cs
@@ -1,11 +1,11 @@
-﻿using Recipes.ModelWithChildren;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.ModelWithChildren;
 using Recipes.RepoDb.Models;
-using RepoDb;
 using RDB = RepoDb;
+using RepoDb;
 using RepoDb.Extensions;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
 
 namespace Recipes.RepoDb.ModelWithChildren

--- a/ORM Cookbook/Recipes.RepoDb/ModelWithLookup/ModelWithLookupComplexScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/ModelWithLookup/ModelWithLookupComplexScenario.cs
@@ -1,11 +1,11 @@
-﻿using Recipes.ModelWithLookup;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.ModelWithLookup;
 using Recipes.RepoDb.Models;
+using RDB = RepoDb;
 using RepoDb;
 using RepoDb.Extensions;
-using RDB = RepoDb;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
 
 namespace Recipes.RepoDb.ModelWithLookup

--- a/ORM Cookbook/Recipes.RepoDb/ModelWithLookup/ModelWithLookupSimpleScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/ModelWithLookup/ModelWithLookupSimpleScenario.cs
@@ -1,11 +1,11 @@
-﻿using Recipes.ModelWithLookup;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.ModelWithLookup;
 using Recipes.RepoDb.Models;
+using RDB = RepoDb;
 using RepoDb;
 using RepoDb.Extensions;
-using RDB = RepoDb;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
 
 namespace Recipes.RepoDb.ModelWithLookup

--- a/ORM Cookbook/Recipes.RepoDb/MultipleCrud/MultipleCrudScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/MultipleCrud/MultipleCrudScenario.cs
@@ -1,10 +1,10 @@
-﻿using Recipes.MultipleCrud;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.MultipleCrud;
 using Recipes.RepoDb.Models;
 using RepoDb;
 using RepoDb.Extensions;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
 
 using RDB = RepoDb;

--- a/ORM Cookbook/Recipes.RepoDb/MultipleCrud/MultipleCrudTests.cs
+++ b/ORM Cookbook/Recipes.RepoDb/MultipleCrud/MultipleCrudTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Recipes.RepoDb;
 using Recipes.RepoDb.Models;
 using Recipes.MultipleCrud;
 

--- a/ORM Cookbook/Recipes.RepoDb/Pagination/PaginationScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/Pagination/PaginationScenario.cs
@@ -1,12 +1,12 @@
-﻿using Recipes.RepoDb.Models;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.RepoDb.Models;
 using Recipes.Pagination;
-using System;
-using System.Collections.Generic;
-using RepoDb;
 using RDB = RepoDb;
-using System.Data.SqlClient;
+using RepoDb;
 using RepoDb.Enumerations;
 using RepoDb.Extensions;
+using System;
+using System.Collections.Generic;
 
 namespace Recipes.RepoDb.Pagination
 {

--- a/ORM Cookbook/Recipes.RepoDb/PartialUpdate/PartialUpdateScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/PartialUpdate/PartialUpdateScenario.cs
@@ -1,9 +1,9 @@
-﻿using Recipes.PartialUpdate;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.PartialUpdate;
 using Recipes.RepoDb.Models;
-using RepoDb;
 using RDB = RepoDb;
+using RepoDb;
 using System;
-using System.Data.SqlClient;
 using System.Linq;
 
 namespace Recipes.RepoDb.PartialUpdate

--- a/ORM Cookbook/Recipes.RepoDb/PopulateDataTable/PopulateDataTableScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/PopulateDataTable/PopulateDataTableScenario.cs
@@ -1,7 +1,7 @@
-﻿using Recipes.PopulateDataTable;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.PopulateDataTable;
 using RepoDb;
 using System.Data;
-using System.Data.SqlClient;
 
 namespace Recipes.RepoDb.PopulateDataTable
 {

--- a/ORM Cookbook/Recipes.RepoDb/Recipes.RepoDb.csproj
+++ b/ORM Cookbook/Recipes.RepoDb/Recipes.RepoDb.csproj
@@ -22,8 +22,9 @@
     </PackageReference>
     
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
-    <PackageReference Include="RepoDb" Version="1.10.5" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.1" />
+    <PackageReference Include="RepoDb.SqlServer" Version="1.0.3" />
+    <PackageReference Include="RepoDb.SqlServer.BulkOperations" Version="1.0.3" />
   </ItemGroup>
 
   

--- a/ORM Cookbook/Recipes.RepoDb/RowCount/RowCountScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/RowCount/RowCountScenario.cs
@@ -1,10 +1,10 @@
-﻿using Recipes.RepoDb.Models;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.RepoDb.Models;
 using Recipes.RowCount;
-using RepoDb;
 using RDB = RepoDb;
+using RepoDb;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 
 namespace Recipes.RepoDb.RowCount
 {

--- a/ORM Cookbook/Recipes.RepoDb/ScalarValue/ScalarValueScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/ScalarValue/ScalarValueScenario.cs
@@ -1,8 +1,8 @@
-﻿using Recipes.ScalarValue;
-using RepoDb;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.ScalarValue;
 using RDB = RepoDb;
+using RepoDb;
 using System;
-using System.Data.SqlClient;
 
 namespace Recipes.RepoDb.ScalarValue
 {

--- a/ORM Cookbook/Recipes.RepoDb/Setup.cs
+++ b/ORM Cookbook/Recipes.RepoDb/Setup.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RDB = RepoDb;
 using System;
 using System.Diagnostics.CodeAnalysis;
 
@@ -29,6 +30,7 @@ namespace Recipes.RepoDb
 
             try
             {
+                RDB.SqlServerBootstrap.Initialize();
                 (new Setup()).Warmup();
             }
             catch { }

--- a/ORM Cookbook/Recipes.RepoDb/SingleColumn/SingleColumnScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/SingleColumn/SingleColumnScenario.cs
@@ -1,11 +1,9 @@
-﻿using Recipes.RepoDb.Models;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.RepoDb.Models;
 using Recipes.SingleColumn;
-using RepoDb;
-
 using RDB = RepoDb;
-
+using RepoDb;
 using System;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Collections.Generic;
 

--- a/ORM Cookbook/Recipes.RepoDb/SingleModelCrud/SingleModelCrudScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/SingleModelCrud/SingleModelCrudScenario.cs
@@ -1,11 +1,11 @@
-﻿using Recipes.RepoDb.Models;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.RepoDb.Models;
 using Recipes.SingleModelCrud;
+using RDB = RepoDb;
 using RepoDb;
 using RepoDb.Extensions;
-using RDB = RepoDb;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
 
 namespace Recipes.RepoDb.SingleModelCrud

--- a/ORM Cookbook/Recipes.RepoDb/SingleModelCrudAsync/SingleModelCrudAsyncScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/SingleModelCrudAsync/SingleModelCrudAsyncScenario.cs
@@ -1,11 +1,11 @@
-﻿using Recipes.RepoDb.Models;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.RepoDb.Models;
 using Recipes.SingleModelCrudAsync;
+using RDB = RepoDb;
 using RepoDb;
 using RepoDb.Extensions;
-using RDB = RepoDb;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/ORM Cookbook/Recipes.RepoDb/Sorting/SortingScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/Sorting/SortingScenario.cs
@@ -1,13 +1,12 @@
-﻿using Recipes.RepoDb.Models;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.RepoDb.Models;
 using Recipes.Sorting;
+using RDB = RepoDb;
 using RepoDb;
 using RepoDb.Extensions;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
-
-using RDB = RepoDb;
 
 namespace Recipes.RepoDb.Sorting
 {

--- a/ORM Cookbook/Recipes.RepoDb/Transactions/TransactionsScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/Transactions/TransactionsScenario.cs
@@ -1,11 +1,11 @@
 ﻿using Recipes.RepoDb.Models;
 using Recipes.Transactions;
-using RepoDb;
 using RDB = RepoDb;
+using RepoDb;
 using System;
 using System.Data;
 using System.Linq;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace Recipes.RepoDb.Transactions
 {

--- a/ORM Cookbook/Recipes.RepoDb/TryCrud/TryCrudScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/TryCrud/TryCrudScenario.cs
@@ -1,10 +1,10 @@
-﻿using Recipes.RepoDb.Models;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.RepoDb.Models;
 using Recipes.TryCrud;
-using RepoDb;
 using RDB = RepoDb;
+using RepoDb;
 using System;
 using System.Data;
-using System.Data.SqlClient;
 using System.Linq;
 
 namespace Recipes.RepoDb.TryCrud

--- a/ORM Cookbook/Recipes.RepoDb/Upsert/UpsertScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/Upsert/UpsertScenario.cs
@@ -1,10 +1,10 @@
-﻿using Recipes.RepoDb.Models;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.RepoDb.Models;
 using Recipes.Upsert;
-using RepoDb;
 using RDB = RepoDb;
+using RepoDb;
 using System;
 using System.Linq;
-using System.Data.SqlClient;
 
 namespace Recipes.RepoDb.Upsert
 {

--- a/ORM Cookbook/Recipes.RepoDb/Views/ViewsScenario.cs
+++ b/ORM Cookbook/Recipes.RepoDb/Views/ViewsScenario.cs
@@ -1,13 +1,11 @@
-﻿using Recipes.RepoDb.Models;
+﻿using Microsoft.Data.SqlClient;
+using Recipes.RepoDb.Models;
 using Recipes.Views;
-using RepoDb;
-
 using RDB = RepoDb;
-
+using RepoDb;
+using RepoDb.Extensions;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
-using RepoDb.Extensions;
 using System.Linq;
 
 namespace Recipes.RepoDb.Views


### PR DESCRIPTION
…rsions.

In version 1.10.7 of RepoDb, the SQL Server functionality has been split and placed into its own dedicated package.

On this update, I had upgraded the RepoDb to version 1.10.9 together with Microsoft.Data.SqlClient to version 1.1.1. In addition, I had added a newly separated package for RepoDb.SqlServer and RepoDb.SqlServer.BulkOperations.